### PR TITLE
Upgrade react-plaid-link to 5.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "tk-test-vite",
+  "name": "layer-quickstart",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "tk-test-vite",
+      "name": "layer-quickstart",
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.18",
@@ -15,7 +15,7 @@
         "plaid": "^41.1.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "react-plaid-link": "^4.1.1",
+        "react-plaid-link": "^5.0.0",
         "uuid": "^13.0.0"
       },
       "devDependencies": {
@@ -4588,9 +4588,9 @@
       "license": "MIT"
     },
     "node_modules/react-plaid-link": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/react-plaid-link/-/react-plaid-link-4.1.1.tgz",
-      "integrity": "sha512-xzAYWQIT/gk+u6lwFAMEZ20f9+AUsCwVyfm64/iudMsyuWANta4wm3Jb7N+APSwuKIR9VUlTkYDhPjLamIGcPA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-plaid-link/-/react-plaid-link-5.0.0.tgz",
+      "integrity": "sha512-DZ/6C7hf+xhEIG9ElCqjk1lty/z+y+wQuV/A29EUx4fxiPLPe7CXN811C3MrCzI7grV45LD7NRS0Do0ma8KIBg==",
       "license": "MIT",
       "dependencies": {
         "prop-types": "^15.7.2"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "plaid": "^41.1.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-plaid-link": "^4.1.1",
+    "react-plaid-link": "^5.0.0",
     "uuid": "^13.0.0"
   },
   "devDependencies": {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -62,8 +62,9 @@ const Home: React.FC = () => {
     onSuccess: (public_token, metadata) => {
       console.log(`Link's onSuccess callback was triggered!`);
       console.log({ public_token, metadata });
-      // Link flows that don't create an Item return a null public token. Layer
-      // always creates one, so this is just belt-and-suspenders.
+      // Link flows that don't create an Item can return a null public token.
+      // Layer still returns one even when no bank is connected (which is how
+      // Extended Autofill works), so this branch is just belt-and-suspenders.
       if (public_token == null) {
         console.log("No Item was created, so there's no identity to fetch.");
         setFlowState(FlowState.MANUAL_FORM);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,5 +1,9 @@
 import { useState, useRef, useEffect } from "react";
-import { usePlaidLink, PlaidLinkOptions } from "react-plaid-link";
+import {
+  usePlaidLink,
+  PlaidLinkOptions,
+  PlaidLinkResult,
+} from "react-plaid-link";
 import Header from "../components/Header";
 import { callMyServer } from "../lib/utils";
 import PhoneInputStep from "../components/PhoneInputStep";
@@ -30,8 +34,7 @@ const Home: React.FC = () => {
   const [debugInfo, setDebugInfo] = useState<string>(
     "Debug info will appear here..."
   );
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  const linkOpenRef = useRef<Function | null>(null);
+  const linkOpenRef = useRef<PlaidLinkResult["open"] | null>(null);
   // Honestly, we're just using this for smarter debug messages
   const usingEARef = useRef<boolean>(false);
 
@@ -59,6 +62,13 @@ const Home: React.FC = () => {
     onSuccess: (public_token, metadata) => {
       console.log(`Link's onSuccess callback was triggered!`);
       console.log({ public_token, metadata });
+      // Link flows that don't create an Item return a null public token. Layer
+      // always creates one, so this is just belt-and-suspenders.
+      if (public_token == null) {
+        console.log("No Item was created, so there's no identity to fetch.");
+        setFlowState(FlowState.MANUAL_FORM);
+        return;
+      }
       callMyServer<AccountSessionInfo>(
         "/server/tokens/fetch_account_session_info",
         true,


### PR DESCRIPTION
[5.0.0](https://github.com/plaid/react-plaid-link/blob/master/MIGRATION.md) corrects react-plaid-link's public TypeScript definitions to match the Link Web SDK; runtime behavior is unchanged. Two of the migration items touch this quickstart:

- `onSuccess` now types `public_token` as `string | null`, so guard it before posting to the server rather than sending `null` and failing on the backend. Layer returns a public token even when no Item is created — which is how Extended Autofill works — so this branch is defensive, but it's the shape a quickstart should demonstrate.
- The newly exported `usePlaidLink` return types let `linkOpenRef` drop its `Function` cast and its `no-unsafe-function-type` suppression.

The migration's Layer-specific change — phone number and date of birth must be sent in separate `submit()` calls — is already what this quickstart does, so the Layer flow itself is unchanged.

Verified by hand in Sandbox, since the flow needs a live Link session: both `submit()` calls round-trip, and `LAYER_NOT_AVAILABLE` / `LAYER_AUTOFILL_NOT_AVAILABLE` are received and handled through to the fallback form with no console errors. I couldn't reach `onSuccess` — the documented test phone number came back Layer-ineligible on my account — so the new null guard is compile-checked but not exercised at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Claude Session: 19fd1818-263e-4ae8-9a08-b337e31f77b9 -->
